### PR TITLE
Fix simulator bug

### DIFF
--- a/ZipZap/ZZFileChannel.m
+++ b/ZipZap/ZZFileChannel.m
@@ -41,7 +41,7 @@
 	
 	NSURL *refUrl = _URL;
 	NSFileProtectionType refProtection = nil;
-	while (!refProtection && refUrl.pathComponents.count) {
+	while (!refProtection && refUrl.pathComponents.count > 1) {
 		NSDictionary *refAttrs = [NSFileManager.defaultManager attributesOfItemAtPath:refUrl.path error:nil];
 		refProtection = refAttrs[NSFileProtectionKey];
 		refUrl = [refUrl URLByDeletingLastPathComponent];


### PR DESCRIPTION
When running mPower2Tests in Simulator, the NSFileProtectionKey doesn’t appear in the attributes at any level of the path, so it’s going all the way up to ‘/‘. And then, apparently, at that point rather than stripping that off and ending up with a path with no components, the URLByDeletingLastPathComponent method starts adding ‘../‘ to the path—so this loop was never terminating.